### PR TITLE
chore: add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Ultra Card",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "demo-server",
+      "command": "python3 -m http.server 8765 --bind 0.0.0.0",
+      "description": "Static server for the standalone card demo. Open http://localhost:8765/website/_local-preview.html?p=modules-page-embed.html (also template-mode-page-embed.html and presets-page-embed.html). Run 'npm run build:demo' to refresh dist-demo/ultra-card-demo.js after changing source."
+    }
+  ],
+  "ports": [
+    {
+      "name": "demo server",
+      "port": 8765
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for Ultra Card.
+# Idempotent: safe to run repeatedly against cached state.
+set -euo pipefail
+
+# package.json pins "engines.node": ">=24.15.0" and CI runs on Node 24
+# (jsdom 30 used by the test suite requires it). The base image ships an older
+# Node, so install the required version with nvm and make it the login default.
+NODE_VERSION="24.15.0"
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+nvm install "$NODE_VERSION"
+nvm alias default "$NODE_VERSION"
+nvm use "$NODE_VERSION"
+
+echo "Using Node $(node --version) / npm $(npm --version)"
+
+# Reproducible install from the committed lockfile.
+npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,10 @@ yarn-error.log*
 .idea
 
 # Cursor IDE
-.cursor/
+.cursor/*
+# Track the Cloud Agent dev environment config
+!.cursor/environment.json
+!.cursor/install.sh
 
 # Planning and implementation documents
 *_PLAN.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for Ultra Card and verifies the toolchain end-to-end.

The repo pins `engines.node` to `>=24.15.0` (and CI moved to Node 24 so `jsdom` 30 used by the test suite works), but the base image ships an older Node. This adds a repo-managed environment that provisions the right toolchain automatically.

## Changes

- `.cursor/install.sh` — idempotent install script that installs Node `24.15.0` via `nvm`, sets it as the login default, and runs `npm ci` from the committed lockfile.
- `.cursor/environment.json` — points `install` at the script and defines a `demo-server` terminal (`python3 -m http.server 8765`) that serves the standalone card demo harness, plus exposes port `8765`.
- `.gitignore` — keeps `.cursor/` ignored except the committed environment config (`environment.json`, `install.sh`).

## Verification

All commands run on Node `24.15.0`:

- `npm run typecheck` — passes (no errors)
- `npm run lint` — 0 errors (warnings only)
- `npm run test:run` — 1071 tests across 78 files pass
- `npm run build` (production) — compiles `ultra-card.js` + `ultra-card-panel.js`
- `npm run build:demo` — compiles `dist-demo/ultra-card-demo.js`
- Served the demo harness and confirmed the Modules, Template Mode, and Presets demo pages render live Ultra Card UI in a browser (interactive template slider works; no bundle load errors).

A login shell resolves Node `24.15.0` purely via the `nvm` default alias, confirming the setup works on a fresh VM.

## How to run

```bash
# Toolchain + deps handled by .cursor/install.sh on boot
npm run dev        # webpack dev server (localhost:8080)
npm run watch      # rebuild on change
npm run build      # production bundles

# View the card demo (demo-server terminal serves this on :8765):
#   http://localhost:8765/website/_local-preview.html?p=modules-page-embed.html
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cac3b85d-47b4-41d6-92aa-a6025f231ec0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cac3b85d-47b4-41d6-92aa-a6025f231ec0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

