### PR TITLE
fix(gauge): center value text in the gauge circle

### DIFF
--- a/src/modules/gauge-module.ts
+++ b/src/modules/gauge-module.ts
@@ -4736,6 +4736,10 @@ export class UltraGaugeModule extends BaseUltraModule {
       styles.push('position: absolute');
       styles.push('top: 50%');
       styles.push('left: 50%');
+      styles.push('line-height: 1');
+      styles.push('display: flex');
+      styles.push('align-items: center');
+      styles.push('justify-content: center');
       styles.push(`transform: translate(calc(-50% + ${xOffset}px), calc(-50% + ${yOffset}px))`);
     } else if (gaugeModule.value_position === 'top') {
       // Calculate top position based on gauge style

--- a/src/modules/gauge-module.ts
+++ b/src/modules/gauge-module.ts
@@ -4734,7 +4734,7 @@ export class UltraGaugeModule extends BaseUltraModule {
 
     if (gaugeModule.value_position === 'center') {
       styles.push('position: absolute');
-      styles.push('top: calc(50% - 15px)'); // Shifted up 15px for optimal arc positioning
+      styles.push('top: 50%');
       styles.push('left: 50%');
       styles.push(`transform: translate(calc(-50% + ${xOffset}px), calc(-50% + ${yOffset}px))`);
     } else if (gaugeModule.value_position === 'top') {

--- a/src/themes/builtin-themes.ts
+++ b/src/themes/builtin-themes.ts
@@ -392,7 +392,7 @@ export const GREEN_TERMINAL_THEME: UcThemeDefinition = {
 // as in iOS light mode; the glass itself stays white and clear.
 const LG_INK = '#10224d';
 const LG_INK_SOFT = 'rgba(16, 34, 77, 0.7)';
-const LG_TINT = 'rgba(255, 255, 255, 0.08)';
+const LG_TINT = 'rgba(255, 255, 255, 0.62)';
 const LG_PRIMARY = '#1b5fd6'; // white on it 5.7:1
 const LG_ACCENT = '#3d8bff';
 const LG_SHADOW_TINT = '30, 60, 140';
@@ -557,7 +557,7 @@ export const LIQUID_GLASS_THEME: UcThemeDefinition = {
       primary: LG_PRIMARY,
       on_primary: '#ffffff',
       accent: LG_ACCENT,
-      card_bg: LG_TINT,
+      card_bg: 'rgba(232, 236, 248, 0.92)',
       text: LG_INK,
       text_secondary: LG_INK_SOFT,
       divider: 'rgba(16, 34, 77, 0.12)',
@@ -597,10 +597,12 @@ export const LIQUID_GLASS_THEME: UcThemeDefinition = {
   --rgb-primary-text-color: 16, 34, 77;
   color: ${LG_INK};
   background-color: ${LG_TINT} !important;
-  /* Specular top-left, a fainter lens light bottom-right, the rest clear. */
+  /* Soft sky wash keeps dark ink readable when the page wallpaper is owned by
+     another card (theme galleries). Specular highlights sit on top. */
   background-image:
-    radial-gradient(120% 70% at 8% 0%, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0) 48%),
-    radial-gradient(80% 50% at 96% 100%, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 55%) !important;
+    radial-gradient(120% 70% at 8% 0%, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0) 48%),
+    radial-gradient(80% 50% at 96% 100%, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0) 55%),
+    linear-gradient(165deg, #d4e6fa 0%, #e8ddf5 48%, #f3d5e8 100%) !important;
   /* See-through: a moderate blur keeps the wallpaper's shapes legible through the pane. */
   backdrop-filter: blur(var(--uc-blur, 10px)) saturate(150%);
   -webkit-backdrop-filter: blur(var(--uc-blur, 10px)) saturate(150%);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the hardcoded `calc(50% - 15px)` upward offset on centered gauge values.
- Centers values with `top: 50%`, `line-height: 1`, and flexbox so digits sit in the ring instead of riding high in a tall line box.
- Makes Liquid Glass self-contained with a stronger frosted tint and soft sky wash so dark ink stays readable when another theme owns the page wallpaper (theme galleries).

## Test plan
- [ ] Open a gauge with `value_position: center` and `gauge_style: radial` — number sits in the middle of the ring.
- [ ] Check `modern` / `arc` styles — values no longer sit high from the old -15px offset.
- [ ] Confirm `value_x_offset` / `value_y_offset` still shift the value as expected.
- [ ] On a multi-theme dashboard, Liquid Glass card text stays readable even if another theme claims the page background.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-965aaeb6-c5f0-591e-bbf3-65ed95a94cb1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-965aaeb6-c5f0-591e-bbf3-65ed95a94cb1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

